### PR TITLE
Specify max_mem with string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.hypothesis

--- a/rechunker/api.py
+++ b/rechunker/api.py
@@ -6,8 +6,8 @@ import dask.array as dsa
 from dask.optimization import fuse
 from dask.delayed import Delayed
 
-
 from rechunker.algorithm import rechunking_plan
+
 
 def rechunk_zarr2zarr_w_dask(source_array, target_chunks, max_mem,
                              target_store, temp_store=None,
@@ -20,10 +20,12 @@ def rechunk_zarr2zarr_w_dask(source_array, target_chunks, max_mem,
     dtype = source_array.dtype
     itemsize = dtype.itemsize
 
+    if isinstance(max_mem, str):
+        max_mem = dask.utils.parse_bytes(max_mem)
+
     read_chunks, int_chunks, write_chunks = rechunking_plan(
         shape, source_chunks, target_chunks, itemsize, max_mem
     )
-
 
     source_read = dsa.from_zarr(source_array, chunks=read_chunks,
                                 storage_options=source_storage_options)


### PR DESCRIPTION
Just making things a bit nicer for the users. Uses dask.utils.parse_bytes to allow `max_mem="128 MB"`, so I've only allowed it in `rechunk_zarr2zarr_w_dask`.

Is the idea to keep `algorithms.py` free of dask? If so, and if we want to allow this in `rechunking_plan` we can just copy dask's implementation. 

I'll have a PR later for automatically determining 